### PR TITLE
Update to use tokio_postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ tokio-postgres = { version = "0.5.2", default_features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.104", features = [ "derive" ] }
+tokio = { version = "0.2.11", features = [ "macros" ] }
+tokio-postgres = "0.5.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "1aim/serde_postgres"
 
 [dependencies]
 serde = "1.0.104"
-tokio-postgres = "0.5.2"
+tokio-postgres = { version = "0.5.2", default_features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.104", features = [ "derive" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,16 +5,16 @@ license = "MIT/Apache-2.0"
 name = "serde_postgres"
 homepage = "https://github.com/1aim/serde_postgres"
 repository = "https://github.com/1aim/serde_postgres.git"
-version = "0.1.3"
+version = "0.2.0"
+edition = "2018"
 
 [badges]
 [badges.travis-ci]
 repository = "1aim/serde_postgres"
 
 [dependencies]
-serde = "1.0.80"
-postgres = "0.15.2"
-# postgres-derive = "0.3.3"
+serde = "1.0.104"
+tokio-postgres = "0.5.2"
 
 [dev-dependencies]
-serde_derive = "1.0.80"
+serde = { version = "1.0.104", features = [ "derive" ] }

--- a/README.md
+++ b/README.md
@@ -4,19 +4,13 @@
 [![Lines Of Code](https://tokei.rs/b1/github/1aim/serde_postgres?category=code)](https://github.com/Aaronepower/tokei)
 [![Documentation](https://docs.rs/serde_postgres/badge.svg)](https://docs.rs/serde_postgres/)
 
-Easily deserialize rows from [`postgres`](//docs.rs/postgres) into
+Easily deserialize rows from [`tokio-postgres`](//docs.rs/tokio-postgres) into
 arbitrary structs. (Only deserialization is supported).
 
 ```rust
-extern crate serde;
-extern crate serde_derive;
-extern crate serde_postgres;
-extern crate postgres;
-
 use std::error::Error;
-
-use serde_derive::Deserialize;
-use postgres::{Connection, TlsMode};
+use serde::Deserialize;
+use tokio_postgres::{connect, NoTls};
 
 #[derive(Clone, Debug, Deserialize)]
 struct Person {
@@ -24,21 +18,23 @@ struct Person {
     age: i32,
 }
 
-fn main() -> Result<(), Box<Error>> {
-    let connection = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None)?;
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let (client, connection) = connect("postgres://postgres@localhost:5432", NoTls).await?;
+    tokio::spawn(connection);
 
-    connection.execute("CREATE TABLE IF NOT EXISTS Person (
+    client.execute("CREATE TABLE IF NOT EXISTS Person (
         name VARCHAR NOT NULL,
         age INT NOT NULL
-    )", &[])?;
+    )", &[]).await?;
 
-    connection.execute("INSERT INTO Person (name, age) VALUES ($1, $2)",
-    &[&"Jane", &23])?;
+    client.execute("INSERT INTO Person (name, age) VALUES ($1, $2)",
+                       &[&"Jane", &23i32]).await?;
 
-    connection.execute("INSERT INTO Person (name, age) VALUES ($1, $2)",
-    &[&"Alice", &32])?;
-    
-    let rows = connection.query("SELECT name, age FROM Person", &[])?;
+    client.execute("INSERT INTO Person (name, age) VALUES ($1, $2)",
+                       &[&"Alice", &32i32]).await?;
+
+    let rows = client.query("SELECT name, age FROM Person", &[]).await?;
 
     let people: Vec<Person> = serde_postgres::from_rows(&rows)?;
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@
 [![Lines Of Code](https://tokei.rs/b1/github/1aim/serde_postgres?category=code)](https://github.com/Aaronepower/tokei)
 [![Documentation](https://docs.rs/serde_postgres/badge.svg)](https://docs.rs/serde_postgres/)
 
-Easily deserialize rows from [`tokio-postgres`](//docs.rs/tokio-postgres) into
+Easily deserialize rows from [`tokio-postgres`](//docs.rs/tokio-postgres) or [`postgres`](//docs.rs/postgres) into
 arbitrary structs. (Only deserialization is supported).
+
+## Examples
+
+**`tokio-postgres`** (asynchronous)
 
 ```rust
 use std::error::Error;
@@ -35,6 +39,45 @@ async fn main() -> Result<(), Box<dyn Error>> {
                        &[&"Alice", &32i32]).await?;
 
     let rows = client.query("SELECT name, age FROM Person", &[]).await?;
+
+    let people: Vec<Person> = serde_postgres::from_rows(&rows)?;
+
+    for person in people {
+        println!("{:?}", person);
+    }
+
+    Ok(())
+}
+```
+
+**`postgres`** (synchronous)
+
+```rust
+use postgres::{Client, NoTls};
+use serde::Deserialize;
+use std::error::Error;
+
+#[derive(Clone, Debug, Deserialize)]
+struct Person {
+    name: String,
+    age: i32,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let mut client = Client::connect("postgres://postgres@localhost:5432", NoTls)?;
+
+    client.execute("CREATE TABLE IF NOT EXISTS Person (
+        name VARCHAR NOT NULL,
+        age INT NOT NULL
+    )", &[])?;
+
+    client.execute("INSERT INTO Person (name, age) VALUES ($1, $2)",
+                   &[&"Jane", &23i32])?;
+    
+    client.execute("INSERT INTO Person (name, age) VALUES ($1, $2)",
+                   &[&"Alice", &32i32])?;
+
+    let rows = client.query("SELECT name, age FROM Person", &[])?;
 
     let people: Vec<Person> = serde_postgres::from_rows(&rows)?;
 

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,41 +1,39 @@
 //! Deserialize postgres rows into a Rust data structure.
-use serde::de::{
-    self,
-    Deserialize,
-    Visitor,
-    IntoDeserializer,
-    value::SeqDeserializer
-};
-
-use postgres::rows::{Row, Rows};
-
-use error::{Error, Result};
+use crate::error::{Error, Result};
+use crate::raw::Raw;
+use serde::de::{self, value::SeqDeserializer, Deserialize, IntoDeserializer, Visitor};
+use tokio_postgres::Row;
 
 /// A structure that deserialize Postgres rows into Rust values.
 pub struct Deserializer<'a> {
-    input: Row<'a>,
+    input: &'a Row,
     index: usize,
 }
 
 impl<'a> Deserializer<'a> {
     /// Create a `Row` deserializer from a `Row`.
-    pub fn from_row(input: Row<'a>) -> Self {
+    pub fn from_row(input: &'a Row) -> Self {
         Self { index: 0, input }
     }
 }
 
 /// Attempt to deserialize from a single `Row`.
-pub fn from_row<'a, T: Deserialize<'a>>(input: Row) -> Result<T> {
+pub fn from_row<'a, T: Deserialize<'a>>(input: &'a Row) -> Result<T> {
     let mut deserializer = Deserializer::from_row(input);
     Ok(T::deserialize(&mut deserializer)?)
 }
 
 /// Attempt to deserialize from `Rows`.
-pub fn from_rows<'a, T: Deserialize<'a>>(input: &'a Rows) -> Result<Vec<T>> {
-    input.into_iter().map(|row| {
-        let mut deserializer = Deserializer::from_row(row);
-        T::deserialize(&mut deserializer)
-    }).collect()
+pub fn from_rows<'a, T: Deserialize<'a>>(
+    input: impl IntoIterator<Item = &'a Row>,
+) -> Result<Vec<T>> {
+    input
+        .into_iter()
+        .map(|row| {
+            let mut deserializer = Deserializer::from_row(row);
+            T::deserialize(&mut deserializer)
+        })
+        .collect::<Result<Vec<T>>>()
 }
 
 macro_rules! unsupported_type {
@@ -49,24 +47,29 @@ macro_rules! unsupported_type {
 }
 
 macro_rules! get_value {
-    ($this:ident, $v:ident, $fn_call:ident, $ty:ty) => {{
-        $v.$fn_call($this.input.get_opt::<_, $ty>($this.index)
-            .unwrap()
-            .map_err(|e| Error::InvalidType(format!("{:?}", e)))?)
-    }}
+    ($this:ident, $ty:ty) => {{
+        $this
+            .input
+            .try_get::<_, $ty>($this.index)
+            .map_err(|e| Error::InvalidType(format!("{:?}", e)))?
+    }};
+}
+
+macro_rules! visit_value {
+    ($this:ident, $ty:ty, $v:ident . $vfn:ident) => {{
+        $v.$vfn(get_value!($this, $ty))
+    }};
 }
 
 impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
     type Error = Error;
 
     unsupported_type! {
-        deserialize_any,
+        deserialize_any, // TODO
         deserialize_u8,
         deserialize_u16,
         deserialize_u64,
         deserialize_char,
-        deserialize_str,
-        deserialize_bytes,
         deserialize_unit,
         deserialize_identifier,
     }
@@ -76,99 +79,93 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
     }
 
     fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_bool, bool)
+        visit_value!(self, bool, visitor.visit_bool)
     }
 
     fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_i8, i8)
+        visit_value!(self, i8, visitor.visit_i8)
     }
 
     fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_i16, i16)
+        visit_value!(self, i16, visitor.visit_i16)
     }
 
     fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_i32, i32)
+        visit_value!(self, i32, visitor.visit_i32)
     }
 
     fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_i64, i64)
+        visit_value!(self, i64, visitor.visit_i64)
     }
 
     fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_u32, u32)
+        visit_value!(self, u32, visitor.visit_u32)
     }
 
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_f32, f32)
+        visit_value!(self, f32, visitor.visit_f32)
     }
 
     fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_f64, f64)
+        visit_value!(self, f64, visitor.visit_f64)
+    }
+
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        visit_value!(self, &str, visitor.visit_str)
     }
 
     fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_string, String)
+        visit_value!(self, String, visitor.visit_string)
+    }
+
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        // TODO: use visit_borrowed_bytes
+        visit_value!(self, &[u8], visitor.visit_bytes)
     }
 
     fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        get_value!(self, visitor, visit_byte_buf, Vec<u8>)
+        visit_value!(self, Vec<u8>, visitor.visit_byte_buf)
     }
 
-    fn deserialize_option<V: Visitor<'de>>(self, visitor: V)
-        -> Result<V::Value>
-    {
-
-        if self.input.get_bytes(self.index).is_some() {
-            visitor.visit_some(self)
-        } else {
-            visitor.visit_none()
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
+        match get_value!(self, Option<Raw>) {
+            Some(_) => visitor.visit_some(self),
+            None => visitor.visit_none(),
         }
     }
 
     fn deserialize_seq<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        let raw = self.input.get_opt::<_, Vec<u8>>(self.index)
-            .unwrap()
-            .map_err(|e| Error::InvalidType(format!("{:?}", e)))?;
-
-        visitor.visit_seq(SeqDeserializer::new(raw.into_iter()))
+        let raw = get_value!(self, Raw);
+        visitor.visit_seq(SeqDeserializer::new(raw.iter().copied()))
     }
 
-
-    fn deserialize_enum<V: Visitor<'de>>(self,
-                                         _: &str,
-                                         _: &[&str],
-                                         _visitor: V)
-        -> Result<V::Value>
-    {
-        //visitor.visit_enum(self)
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _: &str,
+        _: &[&str],
+        _visitor: V,
+    ) -> Result<V::Value> {
         Err(Error::UnsupportedType)
     }
 
-    fn deserialize_unit_struct<V: Visitor<'de>>(self, _: &str, _: V)
-        -> Result<V::Value>
-    {
+    fn deserialize_unit_struct<V: Visitor<'de>>(self, _: &str, _: V) -> Result<V::Value> {
         Err(Error::UnsupportedType)
     }
 
-    fn deserialize_newtype_struct<V: Visitor<'de>>(self, _: &str, _: V)
-        -> Result<V::Value>
-    {
+    fn deserialize_newtype_struct<V: Visitor<'de>>(self, _: &str, _: V) -> Result<V::Value> {
         Err(Error::UnsupportedType)
     }
 
-    fn deserialize_tuple<V: Visitor<'de>>(self, _: usize, _: V)
-        -> Result<V::Value>
-    {
+    fn deserialize_tuple<V: Visitor<'de>>(self, _: usize, _: V) -> Result<V::Value> {
         Err(Error::UnsupportedType)
     }
 
-    fn deserialize_tuple_struct<V: Visitor<'de>>(self,
-                                                 _: &str,
-                                                 _: usize,
-                                                 _: V)
-        -> Result<V::Value>
-    {
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _: &str,
+        _: usize,
+        _: V,
+    ) -> Result<V::Value> {
         Err(Error::UnsupportedType)
     }
 
@@ -176,7 +173,12 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
         visitor.visit_map(self)
     }
 
-    fn deserialize_struct<V: Visitor<'de>>(self, _: &'static str, _: &'static [&'static str], v: V) -> Result<V::Value> {
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _: &'static str,
+        _: &'static [&'static str],
+        v: V,
+    ) -> Result<V::Value> {
         self.deserialize_map(v)
     }
 }
@@ -184,24 +186,20 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
 impl<'de, 'a> de::MapAccess<'de> for Deserializer<'a> {
     type Error = Error;
 
-    fn next_key_seed<T: de::DeserializeSeed<'de>>(&mut self, seed: T)
-        -> Result<Option<T::Value>>
-    {
+    fn next_key_seed<T: de::DeserializeSeed<'de>>(&mut self, seed: T) -> Result<Option<T::Value>> {
         if self.index >= self.input.columns().len() {
-            return Ok(None)
+            return Ok(None);
         }
 
-        self.input.columns()
+        self.input
+            .columns()
             .get(self.index)
             .ok_or(Error::UnknownField)
             .map(|c| c.name().to_owned().into_deserializer())
             .and_then(|n| seed.deserialize(n).map(Some))
-
     }
 
-    fn next_value_seed<T: de::DeserializeSeed<'de>>(&mut self, seed: T)
-        -> Result<T::Value>
-    {
+    fn next_value_seed<T: de::DeserializeSeed<'de>>(&mut self, seed: T) -> Result<T::Value> {
         let result = seed.deserialize(&mut *self);
         self.index += 1;
         if let Err(Error::InvalidType(err)) = result {
@@ -264,10 +262,18 @@ mod tests {
 
     fn setup_and_connect_to_db() -> Connection {
         let user = env::var("PGUSER").unwrap_or("postgres".into());
-        let pass = env::var("PGPASSWORD").map(|p| format!("{}", p)).unwrap_or("postgres".into());
+        let pass = env::var("PGPASSWORD")
+            .map(|p| format!("{}", p))
+            .unwrap_or("postgres".into());
         let addr = env::var("PGADDR").unwrap_or("localhost".into());
         let port = env::var("PGPORT").unwrap_or("5432".into());
-        let url = format!("postgres://{user}:{pass}@{addr}:{port}", user = user, pass = pass, addr = addr, port = port);
+        let url = format!(
+            "postgres://{user}:{pass}@{addr}:{port}",
+            user = user,
+            pass = pass,
+            addr = addr,
+            port = port
+        );
         Connection::connect(url, postgres::TlsMode::None).unwrap()
     }
 
@@ -287,7 +293,9 @@ mod tests {
 
         let connection = setup_and_connect_to_db();
 
-        connection.execute("CREATE TABLE IF NOT EXISTS Buu (
+        connection
+            .execute(
+                "CREATE TABLE IF NOT EXISTS Buu (
                     wants_candy BOOL NOT NULL,
                     width SMALLINT NOT NULL,
                     amount_eaten INT NOT NULL,
@@ -296,9 +304,14 @@ mod tests {
                     weight DOUBLE PRECISION NOT NULL,
                     catchphrase VARCHAR NOT NULL,
                     stomach_contents BYTEA NOT NULL
-        )", &[]).unwrap();
+        )",
+                &[],
+            )
+            .unwrap();
 
-        connection.execute("INSERT INTO Buu (
+        connection
+            .execute(
+                "INSERT INTO Buu (
             wants_candy,
             width,
             amount_eaten,
@@ -308,9 +321,22 @@ mod tests {
             catchphrase,
             stomach_contents
         ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)",
-        &[&true, &20i16, &1000i32, &1000_000i64, &99.99f32, &9999.9999f64, &String::from("Woo Woo"), &vec![1u8, 2, 3, 4, 5, 6]]).unwrap();
+                &[
+                    &true,
+                    &20i16,
+                    &1000i32,
+                    &1000_000i64,
+                    &99.99f32,
+                    &9999.9999f64,
+                    &String::from("Woo Woo"),
+                    &vec![1u8, 2, 3, 4, 5, 6],
+                ],
+            )
+            .unwrap();
 
-        let results = connection.query("SELECT wants_candy,
+        let results = connection
+            .query(
+                "SELECT wants_candy,
             width,
             amount_eaten,
             amount_want_to_eat,
@@ -318,7 +344,10 @@ mod tests {
             weight,
             catchphrase,
             stomach_contents
- FROM Buu", &[]).unwrap();
+ FROM Buu",
+                &[],
+            )
+            .unwrap();
 
         let row = results.get(0);
 
@@ -331,7 +360,7 @@ mod tests {
         assert_eq!(99.99, buu.speed);
         assert_eq!(9999.9999, buu.weight);
         assert_eq!("Woo Woo", buu.catchphrase);
-        assert_eq!(vec![1,2,3,4,5,6], buu.stomach_contents);
+        assert_eq!(vec![1, 2, 3, 4, 5, 6], buu.stomach_contents);
 
         connection.execute("DROP TABLE Buu", &[]).unwrap();
     }
@@ -352,7 +381,9 @@ mod tests {
 
         let connection = setup_and_connect_to_db();
 
-        connection.execute("CREATE TABLE IF NOT EXISTS NullBuu (
+        connection
+            .execute(
+                "CREATE TABLE IF NOT EXISTS NullBuu (
                     wants_candy BOOL,
                     width SMALLINT,
                     amount_eaten INT,
@@ -361,9 +392,14 @@ mod tests {
                     weight DOUBLE PRECISION,
                     catchphrase VARCHAR,
                     stomach_contents BYTEA
-        )", &[]).unwrap();
+        )",
+                &[],
+            )
+            .unwrap();
 
-        connection.execute("INSERT INTO NullBuu (
+        connection
+            .execute(
+                "INSERT INTO NullBuu (
             wants_candy,
             width,
             amount_eaten,
@@ -381,9 +417,13 @@ mod tests {
             NULL,
             NULL,
             NULL)",
-        &[]).unwrap();
+                &[],
+            )
+            .unwrap();
 
-        let results = connection.query("SELECT wants_candy,
+        let results = connection
+            .query(
+                "SELECT wants_candy,
             width,
             amount_eaten,
             amount_want_to_eat,
@@ -391,7 +431,10 @@ mod tests {
             weight,
             catchphrase,
             stomach_contents
- FROM NullBuu", &[]).unwrap();
+ FROM NullBuu",
+                &[],
+            )
+            .unwrap();
 
         let row = results.get(0);
 
@@ -418,22 +461,36 @@ mod tests {
 
         let connection = setup_and_connect_to_db();
 
-        connection.execute("CREATE TABLE IF NOT EXISTS SpellBuu (
+        connection
+            .execute(
+                "CREATE TABLE IF NOT EXISTS SpellBuu (
                     wants_candy BOOL NOT NULL
-        )", &[]).unwrap();
+        )",
+                &[],
+            )
+            .unwrap();
 
-        connection.execute("INSERT INTO SpellBuu (
+        connection
+            .execute(
+                "INSERT INTO SpellBuu (
             wants_candy
         ) VALUES ($1)",
-        &[&true]).unwrap();
+                &[&true],
+            )
+            .unwrap();
 
-        let results = connection.query("SELECT wants_candy FROM SpellBuu", &[]).unwrap();
+        let results = connection
+            .query("SELECT wants_candy FROM SpellBuu", &[])
+            .unwrap();
 
         let row = results.get(0);
 
         assert_eq!(
             super::from_row::<Buu>(row),
-            Err(super::Error::Message(String::from("missing field `wants_candie`"))));
+            Err(super::Error::Message(String::from(
+                "missing field `wants_candie`"
+            )))
+        );
 
         connection.execute("DROP TABLE SpellBuu", &[]).unwrap();
     }
@@ -447,22 +504,36 @@ mod tests {
 
         let connection = setup_and_connect_to_db();
 
-        connection.execute("CREATE TABLE IF NOT EXISTS MiBuu (
+        connection
+            .execute(
+                "CREATE TABLE IF NOT EXISTS MiBuu (
                     wants_candy BOOL
-        )", &[]).unwrap();
+        )",
+                &[],
+            )
+            .unwrap();
 
-        connection.execute("INSERT INTO MiBuu (
+        connection
+            .execute(
+                "INSERT INTO MiBuu (
             wants_candy
         ) VALUES ($1)",
-        &[&None::<bool>]).unwrap();
+                &[&None::<bool>],
+            )
+            .unwrap();
 
-        let results = connection.query("SELECT wants_candy FROM MiBuu", &[]).unwrap();
+        let results = connection
+            .query("SELECT wants_candy FROM MiBuu", &[])
+            .unwrap();
 
         let row = results.get(0);
 
         assert_eq!(
             super::from_row::<Buu>(row),
-            Err(super::Error::InvalidType(String::from("wants_candy Error(Conversion(WasNull))"))));
+            Err(super::Error::InvalidType(String::from(
+                "wants_candy Error(Conversion(WasNull))"
+            )))
+        );
 
         connection.execute("DROP TABLE MiBuu", &[]).unwrap();
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -2,6 +2,7 @@
 use crate::error::{Error, Result};
 use crate::raw::Raw;
 use serde::de::{self, value::SeqDeserializer, Deserialize, IntoDeserializer, Visitor};
+use std::iter::FromIterator;
 use tokio_postgres::Row;
 
 /// A structure that deserialize Postgres rows into Rust values.
@@ -23,17 +24,17 @@ pub fn from_row<'a, T: Deserialize<'a>>(input: &'a Row) -> Result<T> {
     Ok(T::deserialize(&mut deserializer)?)
 }
 
-/// Attempt to deserialize from `Rows`.
-pub fn from_rows<'a, T: Deserialize<'a>>(
+/// Attempt to deserialize multiple `Rows`.
+pub fn from_rows<'a, T: Deserialize<'a>, I: FromIterator<T>>(
     input: impl IntoIterator<Item = &'a Row>,
-) -> Result<Vec<T>> {
+) -> Result<I> {
     input
         .into_iter()
         .map(|row| {
             let mut deserializer = Deserializer::from_row(row);
             T::deserialize(&mut deserializer)
         })
-        .collect::<Result<Vec<T>>>()
+        .collect()
 }
 
 macro_rules! unsupported_type {

--- a/src/de.rs
+++ b/src/de.rs
@@ -59,6 +59,10 @@ macro_rules! visit_value {
     ($this:ident, $ty:ty, $v:ident . $vfn:ident) => {{
         $v.$vfn(get_value!($this, $ty))
     }};
+
+    ($this:ident, $v:ident . $vfn:ident) => {
+        visit_value!($this, _, $v.$vfn)
+    };
 }
 
 impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
@@ -79,52 +83,52 @@ impl<'de, 'a, 'b> de::Deserializer<'de> for &'b mut Deserializer<'a> {
     }
 
     fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, bool, visitor.visit_bool)
+        visit_value!(self, visitor.visit_bool)
     }
 
     fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, i8, visitor.visit_i8)
+        visit_value!(self, visitor.visit_i8)
     }
 
     fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, i16, visitor.visit_i16)
+        visit_value!(self, visitor.visit_i16)
     }
 
     fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, i32, visitor.visit_i32)
+        visit_value!(self, visitor.visit_i32)
     }
 
     fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, i64, visitor.visit_i64)
+        visit_value!(self, visitor.visit_i64)
     }
 
     fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, u32, visitor.visit_u32)
+        visit_value!(self, visitor.visit_u32)
     }
 
     fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, f32, visitor.visit_f32)
+        visit_value!(self, visitor.visit_f32)
     }
 
     fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, f64, visitor.visit_f64)
+        visit_value!(self, visitor.visit_f64)
     }
 
     fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, &str, visitor.visit_str)
+        visit_value!(self, visitor.visit_str)
     }
 
     fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, String, visitor.visit_string)
+        visit_value!(self, visitor.visit_string)
     }
 
     fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
         // TODO: use visit_borrowed_bytes
-        visit_value!(self, &[u8], visitor.visit_bytes)
+        visit_value!(self, visitor.visit_bytes)
     }
 
     fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {
-        visit_value!(self, Vec<u8>, visitor.visit_byte_buf)
+        visit_value!(self, visitor.visit_byte_buf)
     }
 
     fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 //! When serializing or deserializing from Postgres rows goes wrong.
-use std::{fmt, error};
-
 use serde::{de, ser};
+use std::{error, fmt};
 
 /// Alias for a `Result` with the error type `serde_postgres::Error`.
 pub type Result<T> = ::std::result::Result<T, Error>;
@@ -10,7 +9,7 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 /// postgres rows.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Error {
-    /// A custom defined error occured. Typically coming from `serde`.
+    /// A custom defined error occurred. Typically coming from `serde`.
     Message(String),
     /// Row contained a field unknown to the data structure.
     UnknownField,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,14 +4,8 @@
 //! arbitrary structs. (Only deserialization is supported).
 //!
 //! ```rust,no_run
-//! extern crate serde;
-//! extern crate serde_derive;
-//! extern crate serde_postgres;
-//! extern crate postgres;
-//!
 //! use std::error::Error;
-//!
-//! use serde_derive::Deserialize;
+//! use serde::Deserialize;
 //! use postgres::{Connection, TlsMode};
 //!
 //! #[derive(Clone, Debug, Deserialize)]
@@ -20,7 +14,7 @@
 //!     age: i32,
 //! }
 //!
-//! fn main() -> Result<(), Box<Error>> {
+//! fn main() -> Result<(), Box<dyn Error>> {
 //!     let connection = Connection::connect("postgres://postgres@localhost:5432", TlsMode::None)?;
 //!
 //!     connection.execute("CREATE TABLE IF NOT EXISTS Person (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,14 +47,9 @@
 //! ```
 #![deny(missing_docs)]
 
-extern crate serde;
-extern crate postgres;
-// extern crate postgres_derive;
-
-#[cfg(test)] extern crate serde_derive;
-
 pub mod de;
 pub mod error;
+mod raw;
 
 pub use de::{from_row, from_rows, Deserializer};
 pub use error::{Error, Result};

--- a/src/raw.rs
+++ b/src/raw.rs
@@ -1,0 +1,27 @@
+use std::error::Error;
+use std::ops::Deref;
+use tokio_postgres::types::{FromSql, Type};
+
+/// The raw bytes of a value, allowing "conversion" from any postgres type.
+///
+/// This type intentionally cannot be converted from `NULL`, and attempting to
+/// do so will result in an error. Instead, use `Option<Raw>`.
+pub struct Raw<'a>(pub &'a [u8]);
+
+impl<'a> FromSql<'a> for Raw<'a> {
+    fn from_sql(_ty: &Type, raw: &'a [u8]) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        Ok(Raw(raw))
+    }
+
+    fn accepts(_ty: &Type) -> bool {
+        true
+    }
+}
+
+impl<'a> Deref for Raw<'a> {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.0
+    }
+}


### PR DESCRIPTION
This is a really useful library, but it can't be used with `tokio_postgres`, or the current versions of `postgres`. This PR updates the project to support the current version of `tokio_postgres` (which also allows it to be used with current versions of `postgres`).

Of course, this is a breaking change, so I've also bumped the version to `0.2.0` in `Cargo.toml`. I've also taken the opportunity to clean up the code a little bit, using 2018 edition features.