### PR TITLE
Update to tokio_postgres 0.6.0 and postgres 0.18.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT/Apache-2.0"
 name = "serde_postgres"
 homepage = "https://github.com/1aim/serde_postgres"
 repository = "https://github.com/1aim/serde_postgres.git"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 
 [badges]
@@ -14,10 +14,10 @@ repository = "1aim/serde_postgres"
 
 [dependencies]
 serde = "1.0.104"
-tokio-postgres = { version = "0.5.2", default_features = false }
+tokio-postgres = { version = "0.6.0", default_features = false }
 
 [dev-dependencies]
 serde = { version = "1.0.104", features = [ "derive" ] }
-tokio = { version = "0.2.11", features = [ "macros" ] }
-tokio-postgres = "0.5.2"
-postgres = "0.17.4"
+tokio = { version = "0.3.4", features = [ "macros", "rt-multi-thread" ] }
+tokio-postgres = "0.6.0"
+postgres = "0.18.1"

--- a/src/de.rs
+++ b/src/de.rs
@@ -524,7 +524,7 @@ mod tests {
         client.execute("INSERT INTO TestPerson (name, age) VALUES ($1, $2)",
                        &[&"Alice", &32i32])?;
 
-        let rows = client.query("SELECT name, age FROM Person", &[])?;
+        let rows = client.query("SELECT name, age FROM TestPerson", &[])?;
 
         let mut people: Vec<Person> = crate::from_rows(&rows).unwrap();
         people.sort();


### PR DESCRIPTION
Minimal update to current tokio_postgres and postgres packages. Passes all tests, fixed broken test.